### PR TITLE
have `re` call `build` instead of `update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ run: $(TARGET)
 	@./$^
 
 .PHONY: re
-re: clean update
+re: clean build
 
 # Linking
 $(TARGET): $(OBJS)


### PR DESCRIPTION
`make re` should not call `make update` as the `update` target is editor specific.

this removes the dependancy on the `bear` program from the `check` target