### PR TITLE
explicitely say which file is being formatted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ clean: test_clean
 
 .PHONY: format
 format:
-	bash aux/norme.sh
+	@echo Formatting
+	@bash aux/norme.sh
 
 .PHONY: check
 check: re

--- a/aux/norme.sh
+++ b/aux/norme.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
 norm() {
+	echo Formatting $1
     python3 -m c_formatter_42 < $1 > temp
     mv temp $1
 }


### PR DESCRIPTION
#17 the bash script `norme.sh` now prints the name of the file it's currently formatting.

this way we can more closely monitor what it's changing